### PR TITLE
Use rebase for reconcilie divergent branches in GIt

### DIFF
--- a/roles/git/files/gitconfig
+++ b/roles/git/files/gitconfig
@@ -10,6 +10,9 @@
 [include]
     path = ~/.gitconfig.local
 
+[pull]
+        rebase = true
+
 [user]
     email = dvrubia@gmail.com
     name = Daniel Vidal de la Rubia


### PR DESCRIPTION
This pull request introduces a small configuration change to the `roles/git/files/gitconfig` file. The change sets Git to use rebase by default when pulling, which helps maintain a cleaner commit history.

* Set `pull.rebase = true` to ensure that `git pull` uses rebase instead of merge by default.